### PR TITLE
Add traceService: enrich traceroute with MaxMind GeoIP, ASN, PTR and RIPEstat data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # Most-Comprehensive-Network-Analyzer-
-Repository name describes itself
+
+## Trace API overview
+
+This service exposes REST endpoints for trace collection, including GeoIP mapping (MaxMind),
+RIPEstat routing context, traceroute hop data, and PTR records.
+
+### Required GeoIP databases
+
+Provide MaxMind MMDB files locally or via environment variables:
+
+- `MAXMIND_COUNTRY_DB` (defaults to `GeoLite2-Country.mmdb` in repo root if present)
+- `MAXMIND_ASN_DB` (defaults to `GeoLite2-ASN.mmdb` in repo root if present)
+
+### Trace endpoint
+
+POST ` /api/trace`
+
+Payload:
+
+```json
+{ "ip": "8.8.8.8" }
+```
+
+Response includes:
+
+- `trace`: traceroute hops (packet timing data where available) with GeoIP, ASN, and PTR records
+- `ripe`: RIPEstat whois, routing-status, prefix-overview, and ASN history
+- `ipv6Mapped`: IPv4-to-IPv6 mapped address for IPv4 targets

--- a/ripeApi.js
+++ b/ripeApi.js
@@ -14,7 +14,6 @@ db.serialize(() => {
 });
 
 // Query RIPEstat API for IP data
-
 const queryRIPEstat = async (ip) => {
   // First, try to get from sqlite3 cache
   return new Promise((resolve, reject) => {
@@ -54,4 +53,39 @@ const queryRIPEstat = async (ip) => {
   });
 };
 
-module.exports = { queryRIPEstat };
+const queryRipeRoutingStatus = async (resource) => {
+  try {
+    const url = `https://stat.ripe.net/data/routing-status/data.json?resource=${resource}`;
+    const response = await axios.get(url);
+    return response.data?.data || null;
+  } catch (error) {
+    throw new Error(`RIPEstat routing-status error: ${error.message}`);
+  }
+};
+
+const queryRipePrefixOverview = async (resource) => {
+  try {
+    const url = `https://stat.ripe.net/data/prefix-overview/data.json?resource=${resource}`;
+    const response = await axios.get(url);
+    return response.data?.data || null;
+  } catch (error) {
+    throw new Error(`RIPEstat prefix-overview error: ${error.message}`);
+  }
+};
+
+const queryRipeAsnHistory = async (resource) => {
+  try {
+    const url = `https://stat.ripe.net/data/asn-history/data.json?resource=${resource}`;
+    const response = await axios.get(url);
+    return response.data?.data || null;
+  } catch (error) {
+    throw new Error(`RIPEstat asn-history error: ${error.message}`);
+  }
+};
+
+module.exports = {
+  queryRIPEstat,
+  queryRipeRoutingStatus,
+  queryRipePrefixOverview,
+  queryRipeAsnHistory,
+};

--- a/server.js
+++ b/server.js
@@ -1,14 +1,13 @@
 const express = require("express");
 const cors = require("cors");
-const maxmind = require("maxmind");
 const axios = require("axios");
 const path = require('path');
 const { execFile } = require("child_process");
 
 const { queryRIPEstat } = require("./ripeApi");
 const { getMacFromArp } = require("./arp");
-const { performTraceroute } = require("./traceroute");
 const { validateIP } = require("./validate");
+const { buildTraceReport } = require("./traceService");
 
 const app = express();
 app.use(express.json());
@@ -86,7 +85,7 @@ app.post("/api/ripe", async (req, res) => {
   }
 });
 
-// Traceroute endpoint with MaxMind GeoIP logging
+// Traceroute endpoint with GeoIP, ASN, PTR, and RIPE routing context
 app.post("/api/traceroute", async (req, res) => {
   const { ip } = req.body;
   if (!ip || !validateIP(ip)) {
@@ -100,14 +99,29 @@ app.post("/api/traceroute", async (req, res) => {
     }
   }
   try {
-    const traceData = await performTraceroute(ip);
-    const lookup = await maxmind.open('./GeoLite2-City.mmdb');
-    const traceWithGeo = traceData.map(hop => {
-      const geo = hop.ip ? lookup.get(hop.ip) : null;
-      console.log(`Hop: ${hop.ip || 'N/A'}, Geo: ${geo ? JSON.stringify(geo.city) : 'Unknown'}`);
-      return { ...hop, geo };
-    });
-    res.json({ ip, trace: traceWithGeo });
+    const report = await buildTraceReport(ip);
+    res.json(report);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Unified trace endpoint (alias for traceroute with additional metadata)
+app.post("/api/trace", async (req, res) => {
+  const { ip } = req.body;
+  if (!ip || !validateIP(ip)) {
+    return res.status(400).json({ error: "Invalid IP address." });
+  }
+  if (isSuspiciousInput(ip)) {
+    await axios.post('/api/log', { event: 'suspicious_input', value: ip });
+    const isMalicious = await analyzePayload(ip);
+    if (isMalicious) {
+      return res.status(400).json({ error: "Malicious payload detected." });
+    }
+  }
+  try {
+    const report = await buildTraceReport(ip);
+    res.json(report);
   } catch (error) {
     res.status(500).json({ error: error.message });
   }

--- a/traceService.js
+++ b/traceService.js
@@ -1,0 +1,131 @@
+const dns = require("dns").promises;
+const fs = require("fs");
+const net = require("net");
+const path = require("path");
+const maxmind = require("maxmind");
+
+const { performTraceroute } = require("./traceroute");
+const {
+  queryRIPEstat,
+  queryRipeRoutingStatus,
+  queryRipePrefixOverview,
+  queryRipeAsnHistory,
+} = require("./ripeApi");
+
+const defaultDbCandidates = {
+  country: ["GeoLite2-Country.mmdb", "GeoLite2-City.mmdb"],
+  asn: ["GeoLite2-ASN.mmdb"],
+};
+
+const maxmindReaders = {
+  country: null,
+  asn: null,
+};
+
+const resolveMaxMindPath = (envKey, candidates) => {
+  if (process.env[envKey]) {
+    return process.env[envKey];
+  }
+  const repoRoot = __dirname;
+  return candidates
+    .map((candidate) => path.join(repoRoot, candidate))
+    .find((candidate) => fs.existsSync(candidate)) || null;
+};
+
+const loadMaxMindReaders = async () => {
+  if (maxmindReaders.country || maxmindReaders.asn) {
+    return;
+  }
+  const countryPath = resolveMaxMindPath("MAXMIND_COUNTRY_DB", defaultDbCandidates.country);
+  const asnPath = resolveMaxMindPath("MAXMIND_ASN_DB", defaultDbCandidates.asn);
+
+  if (countryPath) {
+    try {
+      maxmindReaders.country = await maxmind.open(countryPath);
+    } catch (error) {
+      console.warn(`MaxMind country DB failed to load: ${error.message}`);
+    }
+  }
+
+  if (asnPath) {
+    try {
+      maxmindReaders.asn = await maxmind.open(asnPath);
+    } catch (error) {
+      console.warn(`MaxMind ASN DB failed to load: ${error.message}`);
+    }
+  }
+};
+
+const lookupGeo = (ip) => {
+  if (!maxmindReaders.country) return null;
+  return maxmindReaders.country.get(ip) || null;
+};
+
+const lookupAsn = (ip) => {
+  if (!maxmindReaders.asn) return null;
+  return maxmindReaders.asn.get(ip) || null;
+};
+
+const mapIpv4ToIpv6 = (ip) => {
+  if (net.isIP(ip) === 4) {
+    return `::ffff:${ip}`;
+  }
+  return ip;
+};
+
+const getPtrRecords = async (ip) => {
+  try {
+    return await dns.reverse(ip);
+  } catch (error) {
+    return [];
+  }
+};
+
+const buildTraceReport = async (ip) => {
+  await loadMaxMindReaders();
+
+  const ipv6Mapped = mapIpv4ToIpv6(ip);
+  const [traceData, whois, routingStatus, prefixOverview, asnHistory, targetPtr] =
+    await Promise.all([
+      performTraceroute(ip),
+      queryRIPEstat(ip),
+      queryRipeRoutingStatus(ip),
+      queryRipePrefixOverview(ip),
+      queryRipeAsnHistory(ip),
+      getPtrRecords(ip),
+    ]);
+
+  const trace = await Promise.all(
+    traceData.map(async (hop) => {
+      if (!hop.ip) {
+        return { ...hop, geo: null, asn: null, ptr: [] };
+      }
+      const [geo, asn, ptr] = await Promise.all([
+        lookupGeo(hop.ip),
+        lookupAsn(hop.ip),
+        getPtrRecords(hop.ip),
+      ]);
+      return {
+        ...hop,
+        geo,
+        asn,
+        ptr,
+      };
+    })
+  );
+
+  return {
+    ip,
+    ipv6Mapped,
+    ptrRecords: targetPtr,
+    ripe: {
+      whois,
+      routingStatus,
+      prefixOverview,
+      asnHistory,
+    },
+    trace,
+  };
+};
+
+module.exports = { buildTraceReport };


### PR DESCRIPTION
### Motivation
- Provide a single, cleaned-up REST trace integration that produces complete trace reports (hops + metadata) instead of ad-hoc lookups in multiple places.  
- Enrich traceroute hops with GeoIP and ASN mapping (MaxMind), PTR records, and RIPEstat routing/prefix/ASN context for deeper network analysis.  
- Make MaxMind DB paths configurable and support IPv4→IPv6 mapped addresses for consistent lookups.

### Description
- Add `traceService.js` which implements `buildTraceReport(ip)` and performs traceroute, loads MaxMind readers (configurable via `MAXMIND_COUNTRY_DB`/`MAXMIND_ASN_DB`), maps IPv4 to IPv6, performs PTR reverse lookups, and aggregates RIPEstat data.  
- Extend `ripeApi.js` with new helpers `queryRipeRoutingStatus`, `queryRipePrefixOverview`, and `queryRipeAsnHistory` in addition to the existing `queryRIPEstat` whois caching.  
- Update `server.js` to replace inline traceroute + MaxMind logic with `buildTraceReport` and add a unified `/api/trace` alias endpoint that returns the enriched report.  
- Document the new trace endpoint and MaxMind DB environment variables in `README.md`.

### Testing
- No automated tests were run against these changes; existing test file `server.test.js` was not executed.  
- Changes were committed locally and basic integration points were exercised in code (no CI or unit test execution performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976aa55a77c832c8239270fdecf95b2)